### PR TITLE
docs: fix dynamic url redirects permission

### DIFF
--- a/src/content/partials/fundamentals/zone-permissions-table.mdx
+++ b/src/content/partials/fundamentals/zone-permissions-table.mdx
@@ -59,8 +59,8 @@ import { Markdown } from "~/components"
 | Response Compression {props.one}          | Grants write access to [Response Compression](/rules/compression-rules/).                                                                  |
 | Sanitize Read                    | Grants read access to sanitization.                                                                                                        |
 | Sanitize {props.one}                      | Grants write access to sanitization.                                                                                                       |
-| Single Redirect Read        | Grants read access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                              |
-| Single Redirect {props.one}          | Grants write access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                             |
+| Dynamic URL Redirects Read        | Grants read access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                              |
+| Dynamic URL Redirects {props.one}          | Grants write access to zone-level [Single Redirects](/rules/url-forwarding/single-redirects/).                                             |
 | SSL and Certificates Read        | Grants read access to [SSL configuration and certificate management](/ssl/).                                                               |
 | SSL and Certificates {props.one}          | Grants write access to [SSL configuration and certificate management](/ssl/).                                                              |
 | Transform Rules Read             | Grants read access to [Transform Rules](/rules/transform/).                                                                                |


### PR DESCRIPTION
### Summary

<!-- Add context such as the type of documentation being updated or added -->
I'm using Terraform to configure API Token permissions, but it gives an error for the `Single Redirect Write` permission. After checking the output of

```hcl
data "cloudflare_api_token_permission_groups" "all" {}
```

I found that the correct permission to use is `Dynamic URL Redirects Write`.

### Documentation checklist

<!-- Remove items that do not apply -->

- [x ] The [documentation style guide](https://developers.cloudflare.com/style-guide/) has been adhered to.
